### PR TITLE
Adding periodic boundary conditions for rod distances

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 3.7)
+project(KMC)
+
+# Set binary output directory to build directory
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+# Require C++11
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED YES)
+
+set(ALLOW_DUPLICATE_CUSTOM_TARGETS TRUE)
+
+if(DEBUG)
+    set(CMAKE_BUILD_TYPE "Debug")
+endif()
+
+if(TESTS)
+  # build in debug mode if we are running unit tests
+    set(CMAKE_BUILD_TYPE "Debug")
+endif()
+
+if(CMAKE_BUILD_TYPE MATCHES "^[Dd]ebug")
+    message("Building KMC in Debug mode")
+else()
+  # otherwise set build to release mode by default
+    set(CMAKE_BUILD_TYPE "Release")
+    message("Building KMC in Release mode")
+endif()
+
+# Require out-of-source builds
+file(TO_CMAKE_PATH "${PROJECT_BINARY_DIR}/CMakeLists.txt" LOC_PATH)
+if(EXISTS "${LOC_PATH}")
+    message(FATAL_ERROR "You cannot build in a source directory (or any directory \
+with a CMakeLists.txt file). Please make a build subdirectory. Feel free to \
+remove CMakeCache.txt and CMakeFiles.")
+endif()
+
+# Add executables
+add_subdirectory("KMC")

--- a/KMC/CMakeLists.txt
+++ b/KMC/CMakeLists.txt
@@ -1,0 +1,11 @@
+find_package(Boost REQUIRED)
+include_directories(${Boost_INCLUDE_DIRS})
+set(LIB ${LIB} ${Boost_LIBRARIES})
+set(TARGET "KMC")
+add_library(${TARGET} INTERFACE)
+target_link_libraries(${TARGET} ${LIB})
+target_include_directories(${TARGET} INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+  $<INSTALL_INTERFACE:include/${TARGET}>
+)

--- a/KMC/kmc.hpp
+++ b/KMC/kmc.hpp
@@ -194,11 +194,11 @@ void KMC<TRod>::UpdateRodDistArr(const int j_rod, const TRod &rod) {
     const double *rScaled = rod.pos;
     double rVec[3], // Rod length vector
         rCenter[3],
-        rMinus[3], // Rod minus end position vector
-        rPlus[3],  // Rod plus end position vector
-        rPos[3],   // Position of protein
-        sepVec[3], // Vector of rod center to protein
-        ds[3];     // Scaled position separation vector
+        rMinus[3],       // Rod minus end position vector
+        rPlus[3],        // Rod plus end position vector
+        rPos[3],         // Position of protein
+        sepVecScaled[3], // Scaled vector of rod center to protein
+        ds[3];           // Scaled position separation vector
 
     /* If we have PBCs, find minimum distance between rod and protein along
        periodic subspace */
@@ -210,11 +210,11 @@ void KMC<TRod>::UpdateRodDistArr(const int j_rod, const TRod &rod) {
     /* If we have PBCs, then we need to rescale rod and protein positions, as
        well as separation vector */
     for (int i = 0; i < n_periodic_; ++i) {
-        sepVec[i] = 0.0;
+        sepVecScaled[i] = 0.0;
         rCenter[i] = 0.0;
         rPos[i] = 0.0;
         for (int j = 0; j < n_periodic_; ++j) {
-            sepVec[i] += unit_cell_[n_dim_ * i + j] * ds[j];
+            sepVecScaled[i] += unit_cell_[n_dim_ * i + j] * ds[j];
             rCenter[i] += unit_cell_[n_dim_ * i + j] * rScaled[j];
             rPos[i] += unit_cell_[n_dim_ * i + j] * rScaled[j];
         }
@@ -222,7 +222,7 @@ void KMC<TRod>::UpdateRodDistArr(const int j_rod, const TRod &rod) {
 
     /* Then handle free subspace. */
     for (int i = n_periodic_; i < 3; ++i) {
-        sepVec[i] = pos_[i] - rScaled[i];
+        sepVecScaled[i] = pos_[i] - rScaled[i];
         rCenter[i] = rScaled[i];
         rPos[i] = pos_[i];
         rVec[i] = rLen * rUVec[i];
@@ -234,10 +234,10 @@ void KMC<TRod>::UpdateRodDistArr(const int j_rod, const TRod &rod) {
     double pointMin[3];
     distMinArr_[j_rod] = dist_point_seg(rPos, rMinus, rPlus, pointMin);
     // Closest point of end_pos along rod axis from rod center.
-    double mu0 = dot3(sepVec, rUVec);
+    double mu0 = dot3(sepVecScaled, rUVec);
     muArr_[j_rod] = mu0;
     // Perpendicular distance away from rod axis
-    distPerpArr_[j_rod] = sqrt(dot3(sepVec, sepVec) - SQR(mu0));
+    distPerpArr_[j_rod] = sqrt(dot3(sepVecScaled, sepVecScaled) - SQR(mu0));
 }
 
 /*! \brief Calculate the probability of a head to bind to surrounding rods.

--- a/KMC/kmc.hpp
+++ b/KMC/kmc.hpp
@@ -1,9 +1,9 @@
 #ifndef KMC_HPP
 #define KMC_HPP
 
-#include "KMC/helpers.hpp"
-#include "KMC/lookup_table.hpp"
-#include "KMC/macros.hpp"
+#include "helpers.hpp"
+#include "lookup_table.hpp"
+#include "macros.hpp"
 
 #include <array>
 #include <cassert>
@@ -13,6 +13,8 @@ template <typename TRod>
 class KMC {
   private:
     // System parameters
+    int n_dim_ = 3;
+    int n_periodic_ = 0;
     const double dt_; // Time step
 
     // Probabilities
@@ -23,6 +25,7 @@ class KMC {
 
     // Spatial variables
     double pos_[3];                   ///< position of motor head
+    double unit_cell_[9];             ///< unit cell matrix for PBCs
     std::vector<double> distMinArr_;  ///< min dist to rod segment
     std::vector<double> distPerpArr_; ///< min (perp) dist to rod line
     std::vector<double> muArr_; ///< Closest points of proteins to rods along
@@ -84,6 +87,19 @@ class KMC {
         distPerpArr_.resize(Npj, 0);
         muArr_.resize(Npj, 0);
         lims_.resize(Npj);
+    }
+
+    /*************************************
+     * Set periodic boundary conditions  *
+     *************************************/
+
+    /* Initialize periodic boundary conditions. This function only needs to be
+       called if there are PBCs. */
+    void SetPBCs(const int n_dim, const int n_periodic,
+                 const double *unit_cell) {
+        n_dim_ = n_dim;
+        n_periodic_ = n_periodic;
+        std::copy(unit_cell, unit_cell + 9, unit_cell_);
     }
 
     /*************************************
@@ -159,6 +175,9 @@ class KMC {
  * as the point located on the rod from rods center where
  * this minimum distance occurs (muArr_).
  *
+ * If we have periodic boundary conditions, then this function expects that
+ * rod.pos will be the scaled position of the rod, and pos_ is the scaled
+ * position of the protein.
  *
  * \param j_rod KMC index of rod used in muArr_ and distPerpArr_
  * \param &rod Rod data structure containing center location, length,
@@ -166,24 +185,53 @@ class KMC {
  * \return void, Updates muArr_[j_rod], distMinArr_[j_rod], and
  * distPerpArr_[j_rod] in KMC object.
  */
+
 template <typename TRod>
 void KMC<TRod>::UpdateRodDistArr(const int j_rod, const TRod &rod) {
     const double rLen = rod.length; // Vector of rod
     const double *rUVec = rod.direction;
-    const double *rCenter = rod.pos;
+    const double *rScaled = rod.pos;
     double rVec[3], // Rod length vector
-        rMinus[3],  // Rod minus end position vector
-        rPlus[3],   // Rod plus end position vector
-        sepVec[3];  // Vector of rod center to protein
-    for (int i = 0; i < 3; ++i) {
+        rCenter[3],
+        rMinus[3], // Rod minus end position vector
+        rPlus[3],  // Rod plus end position vector
+        rPos[3],   // Position of protein
+        sepVec[3], // Vector of rod center to protein
+        ds[3];     // Scaled position separation vector
+
+    /* If we have PBCs, find minimum distance between rod and protein along
+       periodic subspace */
+    for (int i = 0; i < n_periodic_; ++i) {
+        ds[i] = pos_[i] - rScaled[i];
+        ds[i] -= NINT(ds[i]);
+    }
+
+    /* If we have PBCs, then we need to rescale rod and protein positions, as
+       well as separation vector */
+    for (int i = 0; i < n_periodic_; ++i) {
+        sepVec[i] = 0.0;
+        rCenter[i] = 0.0;
+        rPos[i] = 0.0;
+        for (int j = 0; j < n_periodic_; ++j) {
+            sepVec[i] += unit_cell_[n_dim_ * i + j] * ds[j];
+            rCenter[i] += unit_cell_[n_dim_ * i + j] * rScaled[j];
+            rPos[i] += unit_cell_[n_dim_ * i + j] * rScaled[j];
+        }
+    }
+
+    /* Then handle free subspace. */
+    for (int i = n_periodic_; i < 3; ++i) {
+        sepVec[i] = pos_[i] - rScaled[i];
+        rCenter[i] = rScaled[i];
+        rPos[i] = pos_[i];
         rVec[i] = rLen * rUVec[i];
         rMinus[i] = rCenter[i] - (.5 * rVec[i]);
         rPlus[i] = rCenter[i] + (.5 * rVec[i]);
-        sepVec[i] = pos_[i] - rCenter[i];
     }
+
     // the perpendicular distance & position from protein ends to rod
     double pointMin[3];
-    distMinArr_[j_rod] = dist_point_seg(pos_, rMinus, rPlus, pointMin);
+    distMinArr_[j_rod] = dist_point_seg(rPos, rMinus, rPlus, pointMin);
     // Closest point of end_pos along rod axis from rod center.
     double mu0 = dot3(sepVec, rUVec);
     muArr_[j_rod] = mu0;

--- a/KMC/lookup_table.hpp
+++ b/KMC/lookup_table.hpp
@@ -16,7 +16,7 @@
 #include <string>
 #include <vector>
 
-#include "KMC/integrals.hpp"
+#include "integrals.hpp"
 /**
  * @brief 2D Lookup Table for the dimensionless functions
  *

--- a/KMC/macros.hpp
+++ b/KMC/macros.hpp
@@ -6,5 +6,6 @@
 #define SQR(x) ((x) * (x))
 #define CUBE(x) ((x) * (x) * (x))
 #define SMALL 1e-8
+#define NINT(x) ((x) < 0.0 ? (int)((x)-0.5) : (int)((x) + 0.5))
 
 #endif /* end of include guard: MACROS_HPP */


### PR DESCRIPTION
# Changes
* Made repo CMake compatible
* Fixed relative paths for #include headers in KMC directory
* Added three new private params to KMC, n_dim_, n_periodic_, and unit_cell_. None of which need to be initialized, but n_periodic_ is default to zero.
* Added setPBCs function for initialization periodic boundary conditions
* UpdateRodDistArr will now properly handle periodic boundary conditions when n_periodic_ > 0, and _should_ have the same behavior as before when PBCs are not initialized (backwards compatibility)

# Issues
* Add unit tests to CMake so that I can easily make sure I didn't break them.
* Add more comments/documentation so users know to use scaled positions along periodic subspace when envoking KMC with initialized PBCs.
* Add unit test to ensure proper behavior when n_periodic_ > 0.