### PR TITLE
Fixed missing lines in UpdateRodDistArr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .DS_Store
 MakefileInc.mk
 doc/
+*.swp

--- a/KMC/kmc.hpp
+++ b/KMC/kmc.hpp
@@ -221,6 +221,9 @@ void KMC<TRod>::UpdateRodDistArr(const int j_rod, const TRod &rod) {
             rCenter[i] += unit_cell_[n_dim_ * i + j] * rScaled[j];
             rPos[i] += unit_cell_[n_dim_ * i + j] * rScaled[j];
         }
+        rVec[i] = rLen * rUVec[i];
+        rMinus[i] = rCenter[i] - (.5 * rVec[i]);
+        rPlus[i] = rCenter[i] + (.5 * rVec[i]);
     }
 
     /* Then handle free subspace. */


### PR DESCRIPTION
# Changed
* Added missing lines that updated `rMinus` and `rPlus` variables in periodic subspace.
* Added vim .swp files to gitignore (for vim users sanity)

# Summary
* Since the two variables above were never updated in periodic subspace, the `distMinArr_` variable was wrong when using periodic boundary conditions. That's fixed now.
* This is why we should test our code before publishing it. 😣

# TODO
* I will add unit tests to ensure KMC step with and without PBCs arrive at same answer given static filaments/crosslinkers and known rng state to avoid this problem in the future.