### PR TITLE
Checks for float imprecision leading to negative values in sqrt

### DIFF
--- a/KMC/kmc.hpp
+++ b/KMC/kmc.hpp
@@ -243,7 +243,12 @@ void KMC<TRod>::UpdateRodDistArr(const int j_rod, const TRod &rod) {
     double mu0 = dot3(sepVecScaled, rUVec);
     muArr_[j_rod] = mu0;
     // Perpendicular distance away from rod axis
-    distPerpArr_[j_rod] = sqrt(dot3(sepVecScaled, sepVecScaled) - SQR(mu0));
+    double distPerpSqr = dot3(sepVecScaled, sepVecScaled) - SQR(mu0);
+    // Avoid floating point errors resulting in negative values in sqrt
+    if (distPerpSqr < 0 && -distPerpSqr < 1e-8) {
+      distPerpSqr = 0;
+    }
+    distPerpArr_[j_rod] = sqrt(distPerpSqr);
 }
 
 /*! \brief Calculate the probability of a head to bind to surrounding rods.


### PR DESCRIPTION
# Changes
* Added a check for negative values when calculating the perpendicular distance between rods. I find that very rarely the distance calculated is negative with a very small absolute value, suggesting floating point errors. This leads the sqrt to blow up and throw a nan.

# Issues
* This seems inelegant so if you can think of a better way to handle this problem, let me know.