### PR TITLE
Jmm/pbcs rcutoff fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,12 +10,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 set(ALLOW_DUPLICATE_CUSTOM_TARGETS TRUE)
 
-if(DEBUG)
-    set(CMAKE_BUILD_TYPE "Debug")
-endif()
-
-if(TESTS)
-  # build in debug mode if we are running unit tests
+if(DEBUG OR UNIT_TESTS)
     set(CMAKE_BUILD_TYPE "Debug")
 endif()
 

--- a/KMC/kmc.hpp
+++ b/KMC/kmc.hpp
@@ -219,7 +219,7 @@ void KMC<TRod>::UpdateRodDistArr(const int j_rod, const TRod &rod) {
         for (int j = 0; j < n_periodic_; ++j) {
             sepVecScaled[i] += unit_cell_[n_dim_ * i + j] * ds[j];
             rCenter[i] += unit_cell_[n_dim_ * i + j] * rScaled[j];
-            rPos[i] += unit_cell_[n_dim_ * i + j] * rScaled[j];
+            rPos[i] += unit_cell_[n_dim_ * i + j] * pos_[j];
         }
         rVec[i] = rLen * rUVec[i];
         rMinus[i] = rCenter[i] - (.5 * rVec[i]);


### PR DESCRIPTION
## Issue
The minimum distance between rods `distMinArr_` (used for comparing to `r_cutoff_`) was not being calculated using the protein position when using periodic BCs, resulting in too many lookups in the lookup table.

## Behavior changes
Fewer table lookups should occur when using pbcs, resulting in fewer warnings about large distPerp between protein and rod. If not using pbcs, there shouldn't be a noticeable difference.

### Other changes
Rearranged some things in `CMakeLists.txt` so that debug mode for KMC would be built if simcore was building unit tests.
